### PR TITLE
Configuration file option in CMDS.p12 and doSeurat_01

### DIFF
--- a/CMDS.p12
+++ b/CMDS.p12
@@ -1,12 +1,13 @@
 #!/bin/bash
 export SDIR="$( cd "$( dirname "$0" )" && pwd )"
 
-VALID_ARGS=$(getopt -o i --long integrate -- "$@")
+VALID_ARGS=$(getopt -o ic: --long integrate,config: -- "$@")
 if [[ $? -ne 0 ]]; then
     exit 1;
 fi
 
 COMBINE=MERGE
+CONFIG_FILE=""
 eval set -- "$VALID_ARGS"
 while [ : ]; do
   case "$1" in
@@ -14,6 +15,12 @@ while [ : ]; do
         echo "Using integrate option for combining samples"
         COMBINE=INTEGRATE
         shift
+        ;;
+    -c | --config)
+        shift
+        CONFIG_FILE=$1
+        shift
+        echo "Using config file [${CONFIG_FILE}]"
         ;;
     --) shift;
         break
@@ -25,20 +32,28 @@ if [ ! -e PROJNAME ]; then
     python3 $SDIR/extractProjectIDFromPath.py $PWD | sed 's/Proj_/p/' >PROJNAME
 fi
 
-time Rscript --no-save $SDIR/doSeuratV5_01.R $* ../cellRanger/s_*
+if [ "$CONFIG_FILE" == "" ]; then
+
+    time Rscript $SDIR/doSeuratV5_01.R $* ../cellRanger/s_*
+
+else
+
+    time Rscript $SDIR/doSeuratV5_01.R CONFIG=$CONFIG_FILE $*
+
+fi
 
 if [ -e pass_00_PARAMS.yaml ]; then
 
     echo "Running phase-II in $COMBINE Mode"
 
     if [ "$COMBINE" != "INTEGRATE" ]; then
-        time Rscript --no-save $SDIR/doSeuratV5_02a_MergeOnly.R pass_01_PARAMS.yaml
+        time Rscript $SDIR/doSeuratV5_02a_MergeOnly.R pass_01_PARAMS.yaml
     else
-        time Rscript --no-save $SDIR/doSeuratV5_02a_IntegrateData.R pass_01_PARAMS.yaml
+        time Rscript $SDIR/doSeuratV5_02a_IntegrateData.R pass_01_PARAMS.yaml
     fi
 
     if [ -e pass_02_PARAMS.yaml ]; then
-        time Rscript --no-save $SDIR/doSeuratV5_02b.R pass_02_PARAMS.yaml
+        time Rscript $SDIR/doSeuratV5_02b.R pass_02_PARAMS.yaml
     else
         echo
         echo "   FATAL ERROR doSeuratV5_02a.R"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # scRNA Version 4
 
-## Branch master (2023-04-30 reconcile with p14049)
+## Branch feat/arc
 
-Needs R>=4.x.
+Needs R>=4.2.
+
+This one has the input fixed to deal with cellranger arc output (Chromium Single Cell Multiome ATAC + Gene Expression) also to deal with external groups running of cellranger (SAIL)
+
+## Previous Updates
 
 Major workflow refactor.
 

--- a/doSeuratV5_01.R
+++ b/doSeuratV5_01.R
@@ -61,7 +61,8 @@ if(args$CONFIG!=".none" & file.exists(args$CONFIG)) {
     config=read_yaml(args$CONFIG)
     inputs=purrr::map(config$inputs,as_tibble) %>% bind_rows
     dataFolders=inputs$dir
-    names(dataFolders)=inputs$sid
+    sampleIDs=inputs$sid
+    names(dataFolders)=sampleIDs
 
 } else {
 


### PR DESCRIPTION
Added an option to specify an configuration file:
- `-c|--config` in CMDS.p12
- `CONFIG=<file>` in doSeurat_01
to allow for explicit data paths to be specified. Ie if we do not have the usual ../cellRanger/s_* setup. 